### PR TITLE
Fix: Resolve touchpad lag caused by event tap resource leaks

### DIFF
--- a/MiddleClick/Controller+Mouse.swift
+++ b/MiddleClick/Controller+Mouse.swift
@@ -16,7 +16,7 @@ extension Controller {
     proxy, type, event, refcon in
     let returnedEvent = Unmanaged.passUnretained(event)
     guard !AppUtils.isIgnoredAppBundle() else { return returnedEvent }
-    
+
     if state.threeDown && (type == .leftMouseDown || type == .rightMouseDown) {
       state.wasThreeDown = true
       event.type = .otherMouseDown
@@ -35,106 +35,106 @@ extension Controller {
 }
 
 class MouseEventHandler {
-    private var eventTap: CFMachPort?
-    private var runLoopSrc: CFRunLoopSource?
+  private var eventTap: CFMachPort?
+  private var runLoopSrc: CFRunLoopSource?
 
-    func registerMouseCallback(callback: CGEventTapCallBack) -> Bool {
-        // If we already have a valid tap, don’t install another one
-        if eventTap != nil && CFMachPortIsValid(eventTap) && runLoopSrc != nil {
-             log.info("Mouse callback already registered.")
-             return true
-        }
-
-        // Ensure any previous state is cleaned up before creating a new one
-        unregisterMouseCallback()
-
-        guard let tap = CGEvent.tapCreate(
-            tap: .cghidEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: .from(
-                .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp
-            ),
-            callback: callback,
-            userInfo: nil
-        ) else {
-            log.error("Failed to create event tap.")
-            return false
-        }
-
-        guard let src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            log.error("Failed to create RunLoop source for event tap.")
-            CFMachPortInvalidate(tap) // Clean up the tap if source creation fails
-            return false
-        }
-
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), src, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
-
-        self.eventTap = tap
-        self.runLoopSrc = src
-
-        log.info("Successfully registered mouse callback.")
-        return true
+  func registerMouseCallback(callback: CGEventTapCallBack) -> Bool {
+    // If we already have a valid tap, don’t install another one
+    if eventTap != nil && CFMachPortIsValid(eventTap) && runLoopSrc != nil {
+      log.info("Mouse callback already registered.")
+      return true
     }
 
+    // Ensure any previous state is cleaned up before creating a new one
+    unregisterMouseCallback()
 
-    func unregisterMouseCallback() {
-        // Use guard to safely unwrap and validate the eventTap
-        guard let tap = eventTap, CFMachPortIsValid(tap) else {
-            // This block executes if eventTap is nil OR if eventTap exists but is invalid.
-            // We can add specific logging if needed, but the main goal is cleanup.
-            if eventTap != nil {
-                // This means eventTap existed but was invalid
-                log.info("Event tap was invalid, cleaning up.")
-            } else {
-                // This means eventTap was nil
-                // log.info("No event tap found to unregister (was nil).") // Optional logging
-            }
-
-            // Ensure state is clean regardless of why the guard failed
-            eventTap = nil
-            runLoopSrc = nil // If the tap is gone/invalid, the source is useless
-            return // Exit the function
-        }
-
-        // --- If guard passes, 'tap' is guaranteed non-nil and valid ---
-
-        // Disable the tap first
-        CGEvent.tapEnable(tap: tap, enable: false)
-
-        // Remove the source from the run loop *if it exists*
-        // (It should exist if 'tap' was valid, but check for safety)
-        if let src = runLoopSrc {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes)
-            // CFRunLoopRemoveSource handles releasing the source
-            self.runLoopSrc = nil // Clear our reference
-        } else {
-             log.info("RunLoop source was unexpectedly nil during unregister for a valid tap.")
-        }
-
-        // Invalidate the underlying Mach port
-        CFMachPortInvalidate(tap)
-        // CFMachPortInvalidate handles releasing the port
-        self.eventTap = nil // Clear our reference
-
-        log.info("Successfully unregistered mouse callback.")
+    guard let tap = CGEvent.tapCreate(
+      tap: .cghidEventTap,
+      place: .headInsertEventTap,
+      options: .defaultTap,
+      eventsOfInterest: .from(
+        .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp
+      ),
+      callback: callback,
+      userInfo: nil
+    ) else {
+      log.error("Failed to create event tap.")
+      return false
     }
 
-    deinit {
-        log.info("MouseEventHandler deinit: ensuring callback is unregistered.")
-        unregisterMouseCallback()
+    guard let src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+      log.error("Failed to create RunLoop source for event tap.")
+      CFMachPortInvalidate(tap) // Clean up the tap if source creation fails
+      return false
     }
+
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), src, .commonModes)
+    CGEvent.tapEnable(tap: tap, enable: true)
+
+    self.eventTap = tap
+    self.runLoopSrc = src
+
+    log.info("Successfully registered mouse callback.")
+    return true
+  }
+
+
+  func unregisterMouseCallback() {
+    // Use guard to safely unwrap and validate the eventTap
+    guard let tap = eventTap, CFMachPortIsValid(tap) else {
+      // This block executes if eventTap is nil OR if eventTap exists but is invalid.
+      // We can add specific logging if needed, but the main goal is cleanup.
+      if eventTap != nil {
+        // This means eventTap existed but was invalid
+        log.info("Event tap was invalid, cleaning up.")
+      } else {
+        // This means eventTap was nil
+        // log.info("No event tap found to unregister (was nil).") // Optional logging
+      }
+
+      // Ensure state is clean regardless of why the guard failed
+      eventTap = nil
+      runLoopSrc = nil // If the tap is gone/invalid, the source is useless
+      return // Exit the function
+    }
+
+    // --- If guard passes, 'tap' is guaranteed non-nil and valid ---
+
+    // Disable the tap first
+    CGEvent.tapEnable(tap: tap, enable: false)
+
+    // Remove the source from the run loop *if it exists*
+    // (It should exist if 'tap' was valid, but check for safety)
+    if let src = runLoopSrc {
+      CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes)
+      // CFRunLoopRemoveSource handles releasing the source
+      self.runLoopSrc = nil // Clear our reference
+    } else {
+      log.info("RunLoop source was unexpectedly nil during unregister for a valid tap.")
+    }
+
+    // Invalidate the underlying Mach port
+    CFMachPortInvalidate(tap)
+    // CFMachPortInvalidate handles releasing the port
+    self.eventTap = nil // Clear our reference
+
+    log.info("Successfully unregistered mouse callback.")
+  }
+
+  deinit {
+    log.info("MouseEventHandler deinit: ensuring callback is unregistered.")
+    unregisterMouseCallback()
+  }
 }
 
 fileprivate extension CGEventMask {
-    static func from(_ types: CGEventType...) -> Self {
-        var mask: UInt64 = 0
-        
-        for type in types {
-            mask |= (1 << type.rawValue)
-        }
+  static func from(_ types: CGEventType...) -> Self {
+    var mask: UInt64 = 0
 
-        return Self(mask)
+    for type in types {
+      mask |= (1 << type.rawValue)
     }
+
+    return Self(mask)
+  }
 }

--- a/MiddleClick/Controller+Mouse.swift
+++ b/MiddleClick/Controller+Mouse.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import CoreFoundation
 
 extension Controller {
   private static let state = GlobalState.shared
@@ -34,55 +35,106 @@ extension Controller {
 }
 
 class MouseEventHandler {
-  private var currentEventTap: CFMachPort?
+    private var eventTap: CFMachPort?
+    private var runLoopSrc: CFRunLoopSource?
 
-  func registerMouseCallback(callback: CGEventTapCallBack) -> Bool {
-    currentEventTap = CGEvent.tapCreate(
-      tap: .cghidEventTap,
-      place: .headInsertEventTap,
-      options: .defaultTap,
-      eventsOfInterest: .from(
-        .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp
-      ),
-      callback: callback,
-      userInfo: nil
-    )
+    func registerMouseCallback(callback: CGEventTapCallBack) -> Bool {
+        // If we already have a valid tap, don’t install another one
+        if eventTap != nil && CFMachPortIsValid(eventTap) && runLoopSrc != nil {
+             log.info("Mouse callback already registered.")
+             return true
+        }
 
-    if let tap = currentEventTap {
-      RunLoop.current.add(tap, forMode: .common)
-      CGEvent.tapEnable(tap: tap, enable: true)
-    } else {
-      return false
+        // Ensure any previous state is cleaned up before creating a new one
+        unregisterMouseCallback()
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: .from(
+                .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp
+            ),
+            callback: callback,
+            userInfo: nil
+        ) else {
+            log.error("Failed to create event tap.")
+            return false
+        }
+
+        guard let src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            log.error("Failed to create RunLoop source for event tap.")
+            CFMachPortInvalidate(tap) // Clean up the tap if source creation fails
+            return false
+        }
+
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), src, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        self.eventTap = tap
+        self.runLoopSrc = src
+
+        log.info("Successfully registered mouse callback.")
+        return true
     }
 
-    return true
-  }
 
-  func unregisterMouseCallback() {
-    guard let eventTap = currentEventTap else {
-      log.info("Could not find the event tap to remove")
-      return
+    func unregisterMouseCallback() {
+        // Use guard to safely unwrap and validate the eventTap
+        guard let tap = eventTap, CFMachPortIsValid(tap) else {
+            // This block executes if eventTap is nil OR if eventTap exists but is invalid.
+            // We can add specific logging if needed, but the main goal is cleanup.
+            if eventTap != nil {
+                // This means eventTap existed but was invalid
+                log.info("Event tap was invalid, cleaning up.")
+            } else {
+                // This means eventTap was nil
+                // log.info("No event tap found to unregister (was nil).") // Optional logging
+            }
+
+            // Ensure state is clean regardless of why the guard failed
+            eventTap = nil
+            runLoopSrc = nil // If the tap is gone/invalid, the source is useless
+            return // Exit the function
+        }
+
+        // --- If guard passes, 'tap' is guaranteed non-nil and valid ---
+
+        // Disable the tap first
+        CGEvent.tapEnable(tap: tap, enable: false)
+
+        // Remove the source from the run loop *if it exists*
+        // (It should exist if 'tap' was valid, but check for safety)
+        if let src = runLoopSrc {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes)
+            // CFRunLoopRemoveSource handles releasing the source
+            self.runLoopSrc = nil // Clear our reference
+        } else {
+             log.info("RunLoop source was unexpectedly nil during unregister for a valid tap.")
+        }
+
+        // Invalidate the underlying Mach port
+        CFMachPortInvalidate(tap)
+        // CFMachPortInvalidate handles releasing the port
+        self.eventTap = nil // Clear our reference
+
+        log.info("Successfully unregistered mouse callback.")
     }
 
-    // Disable the event tap first
-    CGEvent.tapEnable(tap: eventTap, enable: false)
-
-    // Remove and release the run loop source
-    RunLoop.current.remove(eventTap, forMode: .common)
-
-    // Release the event tap
-    currentEventTap = nil
-  }
+    deinit {
+        log.info("MouseEventHandler deinit: ensuring callback is unregistered.")
+        unregisterMouseCallback()
+    }
 }
 
 fileprivate extension CGEventMask {
-  static func from(_ types: CGEventType...) -> Self {
-    var mask = 0
+    static func from(_ types: CGEventType...) -> Self {
+        var mask: UInt64 = 0
+        
+        for type in types {
+            mask |= (1 << type.rawValue)
+        }
 
-    for type in types {
-      mask |= (1 << type.rawValue)
+        return Self(mask)
     }
-
-    return Self(mask)
-  }
 }


### PR DESCRIPTION
**Fixes #77, #105, and #111**

Hi!

This pull request addresses a performance degradation issue where touchpad scrolling and gestures become laggy over extended use.

**Problem:**
This pull request addresses the issue where MiddleClick causes progressively worsening trackpad lag (scrolling, gestures) over time. This often becomes noticeable after sleep/wake cycles or display reconfigurations, requiring an application restart to restore performance.

The root cause is a resource leak related to how the `CGEventTap`'s `CFMachPort` was managed within the `RunLoop`:

1.  `CGEvent.tapCreate` returns a `CFMachPort`.
2.  The previous code added this port directly to the `RunLoop` (`RunLoop.current.add(...)`). Internally, `CFRunLoop` creates a `CFRunLoopSource` wrapper to monitor this port.
3.  The cleanup code attempted to remove the original `CFMachPort` (`RunLoop.current.remove(...)`), which failed because the run loop manages the *wrapper source*, not the original port directly.
4.  This resulted in **orphaned `CFRunLoopSource` objects** remaining active every time listeners were re-registered (e.g., after sleep/wake).
5.  These accumulating sources consumed resources and interfered with the input event stream, causing the progressive lag.

**Solution:**
This PR modifies `Controller+Mouse.swift` to manage the run loop source explicitly and correctly using CoreFoundation APIs:

1.  An explicit `CFRunLoopSource` is now created for the event tap's port using `CFMachPortCreateRunLoopSource`.
2.  This *specific source* is added to the run loop via `CFRunLoopAddSource`.
3.  During cleanup, `CFRunLoopRemoveSource` removes the *exact source* that was added.
4.  `CFMachPortInvalidate` is called on the port during cleanup to explicitly release system resources and break potential cycles.
5.  Additional validation checks (`CFMachPortIsValid`) have been integrated into the registration and cleanup logic for increased robustness against potentially invalid tap states.

**Testing:**
I've tested this fix locally over the past week. The touchpad performance remains consistently smooth, and the previous lag issue is no longer reproducible. The core three-finger tap functionality remains unaffected.

**Impact:**
This change significantly improves the application's stability and user experience for long sessions by preventing resource leaks that caused system-wide input lag. It directly fixes the reported performance degradation without altering the application's primary features.